### PR TITLE
Add typecheck step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+    - name: typecheck
+      run: |
+        bundle exec rake typecheck
     - name: Setup database
       run: |
         cat docker/mysql/initdb.d/01_schema.sql | mysql -h 127.0.0.1 -u root -ppassword rspec_explain_test


### PR DESCRIPTION
## Summary
- Add typecheck step to GitHub Actions CI workflow to ensure type safety
- Uses 'bundle exec rake typecheck' to run Sorbet type checks

## Test plan
- CI should run the Sorbet type checks successfully